### PR TITLE
patch: scorecard.yml

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ on:
   schedule:
     - cron: "41 23 * * 4"
   push:
-    branches: ["main", "dev"]
+    branches: ["main"]
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
## Description

Quick patch to remove branch dev from the scorecard.yml as OSSF-Scorecard only supports analysis on the **main** branch